### PR TITLE
Add psql native functions 'point' and 'polygon'

### DIFF
--- a/src/queryparser/adql/adqltranslator.py
+++ b/src/queryparser/adql/adqltranslator.py
@@ -205,7 +205,7 @@ class ADQLGeometryTranslationVisitor(ADQLParserVisitor):
             if derived_column is not None:
                 ctx_text = f"spoint_to_array_deg({ctx_text})"
                 if not (any([isinstance(child, ADQLParser.As_clauseContext) for child in derived_column.children])):
-                    ctx_text = f"{ctx_text} AS point"
+                    ctx_text = f"{ctx_text} AS adql_point"
         else:
             ctx_text = ''
 
@@ -297,7 +297,7 @@ class ADQLGeometryTranslationVisitor(ADQLParserVisitor):
                 if derived_column is not None:
                     ctx_text = f"spoly_to_array_deg({ctx_text})"
                     if not (any([isinstance(child, ADQLParser.As_clauseContext) for child in derived_column.children])):
-                        ctx_text = f"{ctx_text} AS polygon"
+                        ctx_text = f"{ctx_text} AS adql_polygon"
         else:
             ctx_text = ''
 

--- a/src/queryparser/postgresql/PostgreSQLLexer.g4
+++ b/src/queryparser/postgresql/PostgreSQLLexer.g4
@@ -130,6 +130,8 @@ OUTER				: O_ U_ T_ E_ R_  ;
 PARTITION_SYM		: P_ A_ R_ T_ I_ T_ I_ O_ N_  ;
 PDIST               : P_ D_ I_ S_ T_ ;
 PI				    : P_ I_  ;
+POINT				  : P_ O_ I_ N_ T_ ;
+POLYGON				: P_ O_ L_ Y_ G_ O_ N_ ;
 POSITION_SYM        : P_ O_ S_ I_ T_ I_ O_ N_ ;
 POW				    : P_ O_ W_  ;
 POWER				: P_ O_ W_ E_ R_  ;

--- a/src/queryparser/postgresql/PostgreSQLParser.g4
+++ b/src/queryparser/postgresql/PostgreSQLParser.g4
@@ -242,8 +242,11 @@ pg_sphere_op:
     | SNOTCONTAINS2 | SLEFTNOTCONTAINS | SLEFTNOTCONTAINS2 | AND_SYM
     | SNOTOVERLAP ;
 
+
 sbit_expr:
-      ( pg_sphere_object | spoint )
+      ( polygon SLEFTCONTAINS2 point )
+    | ( point SCONTAINS2 polygon )
+    | ( pg_sphere_object | spoint )
     | ( ( spoint | simple_expr ) pg_sphere_op pg_sphere_object)
     | ( pg_sphere_object EQ pg_sphere_object )
     | ( pg_sphere_object pg_sphere_op pg_sphere_object )
@@ -255,6 +258,8 @@ sbit_expr:
     | ( ( spoint | scircle | sline | sellipse | spoly | spath | simple_expr ) ( ( PLUS | MINUS )? strans )+ ) ;
 
 
+polygon:                POLYGON string_literal ;
+point:                  POINT LPAREN bit_expr COMMA bit_expr RPAREN ;
 spoint:                 SPOINT LPAREN bit_expr COMMA bit_expr RPAREN ;
 scircle:                SCIRCLE LPAREN spoint COMMA bit_expr RPAREN ;
 sline:                  ( SLINE LPAREN spoint COMMA spoint RPAREN ) | ( SLINE LPAREN strans COMMA bit_expr RPAREN );

--- a/src/queryparser/testing/tests.yaml
+++ b/src/queryparser/testing/tests.yaml
@@ -886,7 +886,7 @@ adql_postgresql_tests:
 
     -
         - SELECT POINT('icrs', 10, 10) FROM "db".tab
-        - SELECT spoint_to_array_deg(spoint(RADIANS(10.0), RADIANS(10.0))) AS point FROM "db".tab;
+        - SELECT spoint_to_array_deg(spoint(RADIANS(10.0), RADIANS(10.0))) AS adql_point FROM "db".tab;
 
     -
         - SELECT POINT(10, 10) AS "p" FROM "db".tab
@@ -898,7 +898,7 @@ adql_postgresql_tests:
 
     -
         - SELECT POLYGON('ICRS', 10.0, -10.5, 20.0, 20.5, 30.0, 30.5) FROM db.tab;
-        - SELECT spoly_to_array_deg(spoly('{(10.0d,-10.5d),(20.0d,20.5d),(30.0d,30.5d)}')) AS polygon FROM db.tab;
+        - SELECT spoly_to_array_deg(spoly('{(10.0d,-10.5d),(20.0d,20.5d),(30.0d,30.5d)}')) AS adql_polygon FROM db.tab;
 
     -
         - SELECT CIRCLE(POINT(10.0, -10.5), 2.0) FROM db.tab;


### PR DESCRIPTION
This PR adds support for the postgreSQL native geometric functions/types `point` and `polygon`. 

Now it is possible to run queries of the type
```sql
SELECT *
FROM "test_schema"."test_table" as t
WHERE POLYGON '((235.04, 24.95), (235.04, 52.90), (272.69, 52.90), (272.69, 24.95), (235.04, 24.95))' @> POINT(t.x, t.y);
```
The query selects all points inside the defined polygon using Cartesian coordinate system.